### PR TITLE
Ny funksjonalitet for datainnsamling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,8 @@ __pycache__/
 *.pyc
 
 # Ignorer midlertidige CSV-filer
-data/gloshaugen_temperaturer.csv
-data/temperatur_renset.csv
+data/temp_gloshaugen_sanntid.csv.csv
+data/temp_gloshaugen_sanntid_renset.csv
 
 # Ignorer API-nøkkelfiler eller miljøfiler
 api.env


### PR DESCRIPTION
Endringer:
-Laster inn FROST_API_KEY fra .env-fil
-Opprettet hent_historiske_temperaturer() for å hente temperaturdata time-for-time gjennom hele 2024 fra Frost API.
-Henter data måned for måned for å unngå feil fra API-et ved store spørringer.
-Begrenser til en tepratur per time med resample("1H").first().

-Fjernet gammel hent_weather_data()-funksjon.
-Erstattet med hent_sanntidsdata() som henter data for de neste 48 timene.

-funksjonen lagre_til_csv er endret slik at sanntids- og historiske data lagres i separate .csv-filer med forklarende navn.

.gitignore er oppdatert for å ekskludere genererte CSV-filer.

