### PR TITLE
oppdatert .gitignore og fjernet api.env fra versjonskontroll 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,8 @@ __pycache__/
 *.pyc
 
 # Ignorer midlertidige CSV-filer
-data/temp_gloshaugen_sanntid.csv.csv
-data/temp_gloshaugen_sanntid_renset.csv
+data/temp_gloshaugen_sanntid_renset_*.csv
+data/temp_gloshaugen_sanntid_*.csv
 
 # Ignorer API-nøkkelfiler eller miljøfiler
 api.env

--- a/api.env
+++ b/api.env
@@ -1,1 +1,0 @@
-USER_AGENT=mappe/1.0 johanne.wiig@gmail.com


### PR DESCRIPTION
Endringer: 
-oppdatert .gitignore og fjernet api.env fra versjonskontroll 
-oppdatert .gitignore til å ignorere alle csv-er som starter med temp_gloshaugen_sanntid_*, slik at at csv-er som er laget i en annen brach ikke tas med inn i main. 