### PR TITLE
Ignorer store og midlertidige csv-er

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,11 @@ __pycache__/
 *.pyc
 
 # Ignorer midlertidige CSV-filer
-data/temp_gloshaugen_sanntid_*.csv
-data/*inneholder_feil*.csv
+*.csv
+!klimagassutslipp_norge_renset.csv
+!klimagassutslipp_verden_renset.csv
+!temp_gloshaugen_historisk_renset_ 50.csv
+!gyldig_historisk_luftkvalitet.csv
 
 # Ignorer API-nøkkelfiler eller miljøfiler
 api.env


### PR DESCRIPTION
Ignorerer alle .csv-filer som standard for å unngå overflødige filer i versjonskontroll
Beholder kun rensede og nødvendige datafiler for å sikre at prosjektet kjører som forventet