### PR TITLE
Forbedret reftime for at dagens dato brukes når mulig

### DIFF
--- a/src/datainnsamling_luft.py
+++ b/src/datainnsamling_luft.py
@@ -14,7 +14,13 @@ def hent_siste_reftime():
         raise Exception(f"Feil ved henting av reftime: {response.status_code}")
     
     reftimes = response.json()["reftimes"]
+    for ref in reversed(reftimes):  
+        if ref.startswith(date.today().isoformat()):
+            return ref
+        
+    print("Fant ikke reftime for i dag, bruker siste tilgjengelige.")
     return reftimes[-1]
+
 
 def hent_sanntids_luftkvalitet():
     load_dotenv('api.env')


### PR DESCRIPTION
Endringer:
-endret funksjonen hent_siste_reftime slik at den henter dagens tilgjengelige reftime fra API. 
Dette gjør at forespørsler bruker nyest mulig tidspunkt for å få  prognoser fram i tid.