### PR TITLE
Ryddet opp i imports strukturen (PEP8)

### DIFF
--- a/src/app_funksjoner.py
+++ b/src/app_funksjoner.py
@@ -2,7 +2,8 @@
 import ipywidgets as widgets
 from IPython.display import display, clear_output
 
-import sys, os
+import os
+import sys
 sys.path.append(os.path.abspath("../src"))
 
 

--- a/src/datainnsamling_temperatur.py
+++ b/src/datainnsamling_temperatur.py
@@ -1,11 +1,11 @@
-import requests
 import csv
 import os
 from datetime import datetime
-import pytz
+
 import pandas as pd
+import pytz
+import requests
 from dotenv import load_dotenv
-from datetime import date
 
 #Hente API-nøkler fra .env 
 load_dotenv('api.env')
@@ -104,7 +104,7 @@ def lagre_til_csv(data, filnavn):
 
 def main():
     lat, lon = 63.4195, 10.4065  # Gløshaugen, Trondheim
-    today = date.today().isoformat()
+    today = datetime.today().isoformat()
     antall_år=50
 
     # Sanntidsdata, 48 neste timene. Genererer ny hver gang

--- a/src/klimagass_visualisering.py
+++ b/src/klimagass_visualisering.py
@@ -1,7 +1,9 @@
-import pandas as pd
+import os
+import sys
+
 import matplotlib.pyplot as plt
 import seaborn as sns
-import sys, os
+
 
 sys.path.append(os.path.abspath("../src"))
 

--- a/src/luftkvalitet_visualisering.py
+++ b/src/luftkvalitet_visualisering.py
@@ -1,10 +1,11 @@
+import sys
+import os
+
 import matplotlib.pyplot as plt
 import seaborn as sns
 import pandas as pd
 from IPython.display import display, HTML
 
-import sys
-import os
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
 
 def plott_årssnitt(df, stoffnavn):

--- a/src/prediksjon_visualisering.py
+++ b/src/prediksjon_visualisering.py
@@ -1,9 +1,11 @@
-import pandas as pd
-from sklearn.linear_model import LinearRegression
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
 import seaborn as sns
-from statistikk import analyser_temperatur, analyser_fil, legg_til_tid, analyser_luftkvalitet
+from sklearn.linear_model import LinearRegression
+
+from statistikk import analyser_temperatur, analyser_fil, legg_til_tid
+
 
 # Kobler temperaturdata og CO₂-utslippsdata basert på år
 def last_og_koble_data(temp_fil, klima_fil):

--- a/src/run_rensing.py
+++ b/src/run_rensing.py
@@ -1,8 +1,10 @@
-import pandas as pd
-from datetime import date
 import os
-from rensing import temperatur_rens, klimagass_rens, rense_luftkvalitet
+from datetime import date
+
+import pandas as pd
+
 from datainnsamling_temperatur import main as hent_temperaturdata_main
+from rensing import temperatur_rens, klimagass_rens, rense_luftkvalitet
 
 
 def rens_og_lagre_temperaturdata():

--- a/src/statistikk.py
+++ b/src/statistikk.py
@@ -1,6 +1,5 @@
 import pandas as pd
 import numpy as np
-import json
 
 # Hjelpefunksjoner
 

--- a/src/temp_visualisering.py
+++ b/src/temp_visualisering.py
@@ -1,15 +1,25 @@
+import os
+import sys
+from datetime import datetime
+
+import numpy as np
+import pandas as pd
 import matplotlib.pyplot as plt
 import seaborn as sns
-import pandas as pd
-from bokeh.plotting import figure, output_notebook, show
-from bokeh.models import ColumnDataSource, HoverTool, Arrow, NormalHead, Annulus, Label
-from datetime import datetime
-from statistikk import beregn_avvik, analyser_temperatur, beregn_endring_totalt
-from datainnsamling_temperatur import hent_temperaturer, hent_sanntidsdata
-import numpy as np
 from IPython.display import display, HTML
+from bokeh.models import (
+    Annulus,
+    Arrow,
+    ColumnDataSource,
+    HoverTool,
+    Label,
+    NormalHead,
+)
+from bokeh.plotting import figure, output_notebook, show
 
-import sys, os
+from datainnsamling_temperatur import hent_sanntidsdata, hent_temperaturer
+from statistikk import analyser_temperatur, beregn_avvik, beregn_endring_totalt
+
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
 
 
@@ -19,7 +29,7 @@ def load_and_compute(path, datokolonne="tidspunkt"):
     df = pd.read_csv(path)
     df[datokolonne] = pd.to_datetime(
         df[datokolonne],
-        format="%Y-%m-%d %H:%M:%S%z",  # riktig rekkefølge: år-måned-dag
+        format="%Y-%m-%d %H:%M:%S%z", 
         utc=True
     )
 
@@ -282,6 +292,9 @@ def plot_sanntids_temperatur(lat=63.4195, lon=10.4065):
         </div>
         """))
         plot_demo_temperatur()
+
+# Kun en demo. Denne blir kjørt om brukeren ikke har api-nøkkel slik at det ikke går å hente sanntidsdata om temperatur 
+# Koden ellers er svært lik funksjonen over som blir kjørt om brukeren har api-nøkkel
 
 def plot_demo_temperatur(filnavn="../data/temp_gloshaugen_sanntid_demo.csv"):
     try:

--- a/src/widgets_app.py
+++ b/src/widgets_app.py
@@ -1,13 +1,15 @@
+import os
+import sys
 
-import ipywidgets as widgets
+from dotenv import load_dotenv
 from IPython.display import display
+import ipywidgets as widgets
+
 from statistikk import analyser_fil, analyser_luftkvalitet, legg_til_tid
 from temp_visualisering import load_and_compute
 
-from dotenv import load_dotenv
 load_dotenv("../api.env")
 
-import os, sys
 sys.path.append(os.path.abspath("../src"))
 
 # Henter data

--- a/tests/test_klimagass.py
+++ b/tests/test_klimagass.py
@@ -1,11 +1,14 @@
-import unittest
-import pandas as pd
-import sys, os
-from io import StringIO
+import os
+import sys
 import tempfile
 from contextlib import redirect_stdout
+from io import StringIO
+import unittest
+
+import pandas as pd
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
 import rensing
 import run_rensing
 

--- a/tests/test_luftkvalitet.py
+++ b/tests/test_luftkvalitet.py
@@ -1,11 +1,15 @@
+import os
+import sys
+from pathlib import Path
 import unittest
-import os, sys 
-import pandas as pd
-from pathlib import Path 
 
+import pandas as pd
+from dotenv import load_dotenv
+
+# Legg til src-mappa i system path
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from dotenv import load_dotenv
+# Last inn miljøvariabler
 load_dotenv()
 
 from datainnsamling_luft import (

--- a/tests/test_prediksjon.py
+++ b/tests/test_prediksjon.py
@@ -1,11 +1,12 @@
-import unittest
-import pandas as pd
-import numpy as np
-
-import sys
 import os
+import sys
+import unittest
+
+import numpy as np
+import pandas as pd
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
 from prediksjon import regresjonsmodell
 
 

--- a/tests/test_rensing.py
+++ b/tests/test_rensing.py
@@ -1,8 +1,11 @@
+import os
+import sys
 import unittest
+
 import pandas as pd
-import sys, os
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
 import rensing
 
 class TestRensing(unittest.TestCase):

--- a/tests/test_temperatur.py
+++ b/tests/test_temperatur.py
@@ -1,10 +1,12 @@
+import os
+import sys
 import unittest
-import os, sys 
+
 import pandas as pd
+from dotenv import load_dotenv
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from dotenv import load_dotenv
 load_dotenv()
 
 from datainnsamling_temperatur import hent_sanntidsdata, hent_temperaturer, hent_historiske_temperaturer


### PR DESCRIPTION
Opprydding av import-strukturen i flere filer slik at den følger PEP8:
Har blandt annet:
-Delte opp i flere linjer (f.eks. import os, sys)
-Sorterte imports etter rekkefølgen: standardbibliotek, tredjepartsbibliotek, egne moduler

